### PR TITLE
6 get api articles id comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -107,7 +107,7 @@ describe("GET /api", () => {
             describe("/comments", () => {
                 test("200: Comments should be retrieved with the necessary properties in an array of objects", () => {
                     return request(app)
-                    .get('/api/articles/3/comments')
+                    .get('/api/articles/1/comments')
                     .expect(200)
                     .then(({body}) => {
                         console.log(body);

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -107,9 +107,10 @@ describe("GET /api", () => {
             describe("/comments", () => {
                 test("200: Comments should be retrieved with the necessary properties in an array of objects", () => {
                     return request(app)
-                    .get('/api/articles/1/comments')
+                    .get('/api/articles/3/comments')
                     .expect(200)
                     .then(({body}) => {
+                        console.log(body);
                         expect(body.comments.length).toBe(11);
                         body.comments.forEach((comment) => {
                             expect(comment).toHaveProperty("comment_id", expect.any(Number));
@@ -129,7 +130,7 @@ describe("GET /api", () => {
                         expect(body.comments).toBeSortedBy("created_at", { descending: true });
                     })
                 })
-                test.only("200: Article with no comments should send empty array", () => {
+                test("200: Article with no comments should send empty array", () => {
                     return request(app)
                     .get('/api/articles/10/comments')
                     .expect(200)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -110,7 +110,6 @@ describe("GET /api", () => {
                     .get('/api/articles/1/comments')
                     .expect(200)
                     .then(({body}) => {
-                        console.log(body)
                         expect(body.comments.length).toBe(11);
                         body.comments.forEach((comment) => {
                             expect(comment).toHaveProperty("comment_id", expect.any(Number));
@@ -130,12 +129,20 @@ describe("GET /api", () => {
                         expect(body.comments).toBeSortedBy("created_at", { descending: true });
                     })
                 })
-                test("200: Article with no comments should send empty array", () => {
+                test.only("200: Article with no comments should send empty array", () => {
                     return request(app)
                     .get('/api/articles/10/comments')
                     .expect(200)
                     .then(({body}) => {
                         expect(body.comments.length).toBe(0);
+                    })
+                })
+                test("404: Should return \"Article ID not found\" if given valid but non-existent ID", () => {
+                    return request(app)
+                    .get('/api/articles/999/comments')
+                    .expect(404)
+                    .then(({body}) => {
+                        expect(body.msg).toBe("Article ID not found")
                     })
                 })
             })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -104,6 +104,33 @@ describe("GET /api", () => {
                     expect(body.msg).toBe("Bad request");
                 })
             })
+            describe("/comments", () => {
+                test("200: Articles retrieved should be sorted by descending order by default.", () => {
+                    return request(app)
+                    .get('/api/articles/1/comments')
+                    .expect(200)
+                    .then(({body}) => {
+                        console.log(body)
+                        expect(body.comments.length).toBe(11);
+                        body.comments.forEach((comment) => {
+                            expect(comment).toHaveProperty("comment_id", expect.any(Number));
+                            expect(comment).toHaveProperty("votes", expect.any(Number));
+                            expect(comment).toHaveProperty("created_at", expect.any(String));
+                            expect(comment).toHaveProperty("author", expect.any(String));
+                            expect(comment).toHaveProperty("body", expect.any(String));
+                            expect(comment).toHaveProperty("article_id", expect.any(Number));
+                        })
+                    })
+                })
+                test("200: Comments should be sorted by most recent first.", () => {
+                    return request(app)
+                    .get('/api/articles/1/comments')
+                    .expect(200)
+                    .then(({body}) => {
+                        expect(body.comments).toBeSortedBy("created_at", { descending: true });
+                    })
+                })
+            })
         })
     })
 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -105,7 +105,7 @@ describe("GET /api", () => {
                 })
             })
             describe("/comments", () => {
-                test("200: Articles retrieved should be sorted by descending order by default.", () => {
+                test("200: Comments should be retrieved with the necessary properties in an array of objects", () => {
                     return request(app)
                     .get('/api/articles/1/comments')
                     .expect(200)
@@ -128,6 +128,14 @@ describe("GET /api", () => {
                     .expect(200)
                     .then(({body}) => {
                         expect(body.comments).toBeSortedBy("created_at", { descending: true });
+                    })
+                })
+                test("200: Article with no comments should send empty array", () => {
+                    return request(app)
+                    .get('/api/articles/10/comments')
+                    .expect(200)
+                    .then(({body}) => {
+                        expect(body.comments.length).toBe(0);
                     })
                 })
             })

--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ app.use((err, req, res, next) => {
 
 //Not Found (404) Error Handling
 app.use((err, req, res, next) => {
+    console.log(err);
     if(err.status === 404){
         res.status(404).send({msg: err.msg});
     } else {

--- a/app.js
+++ b/app.js
@@ -33,7 +33,6 @@ app.use((err, req, res, next) => {
 
 //Not Found (404) Error Handling
 app.use((err, req, res, next) => {
-    console.log(err);
     if(err.status === 404){
         res.status(404).send({msg: err.msg});
     } else {

--- a/app.js
+++ b/app.js
@@ -3,8 +3,9 @@ const app = express();
 
 const { getApi } = require("./controllers/api-controllers.js");
 const { getTopics } = require("./controllers/topics-controllers.js");
-const { getArticleById,
-        getArticles } = require("./controllers/articles-controllers.js");
+const { getArticles,
+        getArticleById,
+        getArticleComments } = require("./controllers/articles-controllers.js");
 
 app.get('/api', getApi);
 
@@ -13,6 +14,8 @@ app.get('/api/topics', getTopics);
 app.get('/api/articles', getArticles);
 
 app.get('/api/articles/:article_id', getArticleById);
+
+app.get('/api/articles/:article_id/comments', getArticleComments);
 
 //Unavailable Route (404) Error Handling
 app.all('*', (req, res) => {

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -21,13 +21,11 @@ module.exports.getArticleComments = (req, res, next) => {
     const checkIdExistsQuery = checkArticleIdExists(article_id);
     const commentsQuery = fetchArticleComments(article_id);
     const queryArray = [commentsQuery, checkIdExistsQuery];
-    Promise.all(queryArray)
+    return Promise.all(queryArray)
     .then((response) => {
-        console.log(response);
         const comments = response[0]
         res.status(200).send({comments});
     }).catch((err) => {
-        console.log(err,  "<-- error over here!");
         next(err);
     });
 }

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -1,5 +1,6 @@
 const { fetchArticleById, 
-        fetchArticles } = require("../models/articles-models.js")
+        fetchArticles,
+        fetchArticleComments } = require("../models/articles-models.js")
 
 module.exports.getArticles = (req, res, next) => {
     return fetchArticles().then((articles) => {
@@ -11,5 +12,12 @@ module.exports.getArticleById = (req, res, next) => {
     const { article_id } = req.params;
     return fetchArticleById(article_id).then((article) => {
         res.status(200).send({article})
+    }).catch(next);
+}
+
+module.exports.getArticleComments = (req, res, next) => {
+    const { article_id } = req.params;
+    return fetchArticleComments(article_id).then((comments) => {
+        res.status(200).send({comments});
     }).catch(next);
 }

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -1,3 +1,4 @@
+const { checkArticleIdExists } = require("../utils.js");
 const { fetchArticleById, 
         fetchArticles,
         fetchArticleComments } = require("../models/articles-models.js")
@@ -17,7 +18,16 @@ module.exports.getArticleById = (req, res, next) => {
 
 module.exports.getArticleComments = (req, res, next) => {
     const { article_id } = req.params;
-    return fetchArticleComments(article_id).then((comments) => {
+    const checkIdExistsQuery = checkArticleIdExists(article_id);
+    const commentsQuery = fetchArticleComments(article_id);
+    const queryArray = [commentsQuery, checkIdExistsQuery];
+    Promise.all(queryArray)
+    .then((response) => {
+        console.log(response);
+        const comments = response[0]
         res.status(200).send({comments});
-    }).catch(next);
+    }).catch((err) => {
+        console.log(err,  "<-- error over here!");
+        next(err);
+    });
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -41,5 +41,29 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "provides an array of all comments on a single article given by ID",
+    "queries": [],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 11,
+          "body": "Ambidextrous marsupial",
+          "article_id": 3,
+          "author": "icellusedkars",
+          "votes": 0,
+          "created_at": "2020-09-19T23:10:00.000Z"
+        },
+        {
+          "comment_id": 10,
+          "body": "git push origin master",
+          "article_id": 3,
+          "author": "icellusedkars",
+          "votes": 0,
+          "created_at": "2020-06-20T07:24:00.000Z"
+        }
+      ]
+    }
   }
 }

--- a/models/articles-models.js
+++ b/models/articles-models.js
@@ -18,7 +18,7 @@ module.exports.fetchArticleById = (article_id) => {
     return db.query(`SELECT * FROM articles WHERE article_id = $1;`, [article_id])
     .then(({rows}) => {
         if (rows.length === 0){
-            return Promise.reject({status: 404, msg: "Article ID not found"})
+            return Promise.reject({status: 404, msg: "Article ID not found"});
         }
         return rows[0];
     })

--- a/models/articles-models.js
+++ b/models/articles-models.js
@@ -23,3 +23,14 @@ module.exports.fetchArticleById = (article_id) => {
         return rows[0];
     })
 }
+
+module.exports.fetchArticleComments = (article_id) => {
+    return db.query(`
+        SELECT * FROM comments 
+        WHERE article_id = $1
+        ORDER BY created_at DESC;
+        `, [article_id])
+        .then(({rows}) => {
+            return rows;
+        })
+}

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 const db = require("./db/connection.js");
 
 module.exports.checkArticleIdExists = (article_id) => {
-    db.query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    return db.query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
     .then(({rows}) => {
         if (rows.length === 0){
             return Promise.reject({status: 404, msg: "Article ID not found"});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,10 @@
+const db = require("./db/connection.js");
+
+module.exports.checkArticleIdExists = (article_id) => {
+    db.query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .then(({rows}) => {
+        if (rows.length === 0){
+            return Promise.reject({status: 404, msg: "Article ID not found"});
+        }
+    });
+};


### PR DESCRIPTION
Added GET /api/articles/:article_id/comments

Tested the following: 
200: Comments should be retrieved with the necessary properties in an array of objects
200: Comments should be sorted by most recent first.
200: Article with no comments should send empty array
400: Should catch invalid IDs in previous testing
404: Should catch valid non-existing IDs in previous testing

Update the Endpoints JSON with the relevant data.