### PR TITLE
9 delete api comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -287,3 +287,34 @@ describe("PATCH /api", () => {
         })
     })
 })
+
+describe("DELETE /api", () => {
+    describe("/comments", () => {
+        describe("/:comment_id", () => {
+            test("204: Successfully delete a comment by comment id, returning no content.", () => {
+                return request(app)
+                .delete("/api/comments/1")
+                .expect(204)
+                .then(({body}) => {
+                    expect(Object.keys(body).length).toBe(0);
+                })
+            })
+            test("400: Bad request should  be handled by existing errors for invalid comment_id", () => {
+                return request(app)
+                .delete("/api/comments/invalid_id")
+                .expect(400)
+                .then(({body}) => {
+                    expect(body.msg).toBe("Bad request")
+                })
+            })
+            test("404: Should return 'Comment ID not found' for valid non-existent comment_id", () => {
+                return request(app)
+                .delete("/api/comments/999")
+                .expect(404)
+                .then(({body}) => {
+                    expect(body.msg).toBe("Comment ID not found");
+                })
+            })
+        })
+    })
+})

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const { getArticles,
         getArticleComments,
         postArticleComment,
         patchArticle } = require("./controllers/articles-controllers.js");
+const { deleteComment } = require("./controllers/comments-controllers.js");
 
 app.use(express.json());
 
@@ -24,6 +25,8 @@ app.get('/api/articles/:article_id/comments', getArticleComments);
 app.post('/api/articles/:article_id/comments', postArticleComment);
 
 app.patch('/api/articles/:article_id', patchArticle);
+
+app.delete('/api/comments/:comment_id', deleteComment);
 
 //Unavailable Route (404) Error Handling
 app.all('*', (req, res) => {

--- a/controllers/comments-controllers.js
+++ b/controllers/comments-controllers.js
@@ -1,0 +1,8 @@
+const { removeComment } = require("../models/comments-models.js")
+
+module.exports.deleteComment = (req, res, next) => {
+    const { comment_id } = req.params;
+    return removeComment(comment_id).then((deleted) => {
+        res.status(204).send();
+    }).catch(next);
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -82,7 +82,7 @@
   },
   "PATCH /api/articles/:article_id": {
     "description": "patches the vote property an article by article_id",
-    "exampleRequest": { "inc_votes": -10},
+    "exampleRequest": { "inc_votes": -10 },
     "exampleResponse": {
       "article": {
         "article_id": 1,
@@ -95,5 +95,9 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes a comment with a given comment_id",
+    "exampleResponse": "responds with a 204 status code and no content"
   }
 }

--- a/models/comments-models.js
+++ b/models/comments-models.js
@@ -1,0 +1,15 @@
+const db = require("../db/connection.js");
+
+module.exports.removeComment = ((comment_id) => {
+    return db.query(`
+        DELETE FROM comments
+        WHERE comment_id = $1;
+        `, [comment_id])
+    .then(({rowCount}) => {
+        console.log(rowCount);
+        if (rowCount === 0) {
+            return Promise.reject({status: 404, msg: "Comment ID not found"});
+        }
+        return { msg: "Succesful deletion" };
+    })
+})

--- a/models/comments-models.js
+++ b/models/comments-models.js
@@ -6,7 +6,6 @@ module.exports.removeComment = ((comment_id) => {
         WHERE comment_id = $1;
         `, [comment_id])
     .then(({rowCount}) => {
-        console.log(rowCount);
         if (rowCount === 0) {
             return Promise.reject({status: 404, msg: "Comment ID not found"});
         }


### PR DESCRIPTION
CORE: DELETE /api/comments/:comment_id

TESTING
204: Successfully delete a comment by comment id, returning no content.
400: Bad request should  be handled by existing errors for invalid comment_id
404: Should return "Comment ID not found" 

DOCUMENTATION
Update the Endpoints JSON with the relevant data.